### PR TITLE
Add restart from GSD

### DIFF
--- a/polybinder/__version__.py
+++ b/polybinder/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 4, 3)
+VERSION = (0, 4, 4)
 
 __version__ = ".".join(map(str, VERSION))

--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -338,10 +338,15 @@ class Simulation:
             integrator.randomize_velocities(seed=self.seed)
             try:
                 hoomd.run(n_steps)
+                print("Simulation completed")
+                done=True
             except hoomd.WalltimeLimitReached:
-                pass
+                print("Walltime limit reached")
+                done=False
             finally:
                 gsd_restart.write_restart()
+                print("Restart GSD file written")
+        return done
 
     def anneal(
         self,

--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -377,7 +377,7 @@ class Simulation:
                 "If shrinking, then all of shirnk_kT, shrink_steps "
                 "and shrink_period need to be given"
             )
-        if shirnk_steps is None:
+        if shrink_steps is None:
             shrink_steps = 0
 
         if not schedule:

--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -529,9 +529,11 @@ class Simulation:
                     last_step += n_steps
                     done = True
                     last_temp = kT
+                    return done, last_temp
                 except hoomd.WalltimeLimitReached:
                     done = False
                     last_temp = kT
+                    return done, last_temp
                 finally:
                     gsd_restart.write_restart()
 

--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -216,9 +216,15 @@ class Simulation:
                     nlist=self.nlist,
                     restart=self.restart
                 )
-                init_x = objs[0].box.Lx
-                init_y = objs[0].box.Ly
-                init_z = objs[0].box.Lz
+                if self.restart is None:
+                    init_x = objs[0].box.Lx
+                    init_y = objs[0].box.Ly
+                    init_z = objs[0].box.Lz
+                else:
+                    init_x = objs[0].configuration.box[0]
+                    init_y = objs[0].configuration.box[1]
+                    init_z = objs[0].configuration.box[2]
+
             elif self.cg_system is True:
                 objs = self._create_hoomd_sim_from_snapshot()
                 self.log_quantities.remove("pair_lj_energy")


### PR DESCRIPTION
This PR adds the ability to restart a simulation from a `restart.gsd` file, which is useful when using polybinder-flow to run jobs on a cluster.