### PR TITLE
add restart file write to anneal function

### DIFF
--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -446,6 +446,10 @@ class Simulation:
             n_steps = schedule[kT]
             self.sim.run(n_steps) 
 
+        hoomd.write.GSD.write(
+                state=self.sim.state, mode='wb', filename="restart.gsd"
+        ) 
+
     def tensile(self,
             kT,
             strain,


### PR DESCRIPTION
Looks like I forgot to include the `restart.gsd` step in the `anneal` simulation function. This PR adds it.