### PR TITLE
fix nlist update typo

### DIFF
--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -321,7 +321,7 @@ class Simulation:
         self.ran_shrink = True
 
         if tree_nlist and isinstance(self.nlist, hoomd.md.nlist.Cell):
-            self.sim.operationsintegrator.forces[0].nlist = original_nlist 
+            self.sim.operations.integrator.forces[0].nlist = original_nlist 
         
     def quench(self, n_steps, kT=None, pressure=None):
         """Runs an NVT or NPT simulation at a single temperature

--- a/polybinder/tests/test_simulations.py
+++ b/polybinder/tests/test_simulations.py
@@ -1,3 +1,4 @@
+import hoomd
 from polybinder import simulate
 from base_test import BaseTest
 
@@ -89,12 +90,20 @@ class TestSimulate(BaseTest):
                 dt=0.0001,
                 mode="cpu"
         )
+        assert isinstance(
+                simulation.sim.operations.integrator.forces[0].nlist,
+                hoomd.md.nlist.Cell
+        )
         simulation.shrink(
                 n_steps=5e2,
                 kT_init=2,
                 kT_final=2,
                 period=1,
                 tree_nlist=True
+        )
+        assert isinstance(
+                simulation.sim.operations.integrator.forces[0].nlist,
+                hoomd.md.nlist.Cell
         )
         simulation.quench(kT=2, pressure=0.1, n_steps=5e2)
 


### PR DESCRIPTION
This fixes a typo when changing the neighborlist from Tree to Cell after running a shrink simulation.