### PR TITLE
change ff to opls for pps fixtures

### DIFF
--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -644,6 +644,9 @@ class Initializer:
                 a.charge = charge
             net_charge = sum([a.charge for a in typed_system.atoms])
             print(f"Resulting net charge of {net_charge}")
+        elif not self.charges and self.forcefield == "opls":
+            for a in typed_system.atoms:
+                a.charge = 0
 
         if self.remove_hydrogens:
             typed_system.strip(

--- a/polybinder/tests/base_test.py
+++ b/polybinder/tests/base_test.py
@@ -72,7 +72,7 @@ class BaseTest:
         pps_sys = Initializer(
                 system_parms,
                 system_type="pack",
-                forcefield="gaff",
+                forcefield="opls",
                 remove_hydrogens=False
         )
         return pps_sys


### PR DESCRIPTION
This PR zero's out the charges populated by foyer when using the oplsaa forcefield. 