### PR TITLE
Save ParmEd structures to file during system initialization

### DIFF
--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -2,7 +2,7 @@ import json
 import os
 import random
 from warnings import warn
-
+import pickle
 import ele
 import foyer
 import gsd
@@ -217,6 +217,8 @@ class Initializer:
             forcefield="gaff",
             charges=None,
             remove_hydrogens=False,
+            save_parmed=True,
+            parmed_dir="pmd_structures",
             **kwargs
     ):
         """
@@ -248,6 +250,10 @@ class Initializer:
             molecule of interest.
         remove_hydrogens : bool, optional, default=False
             If True, hydrogen atoms are removed from the system.
+        save_parmed : bool, optional, default=True
+            If True, the parmed structure is saved to the file.
+        parmed_dir: str, optional, default="pmd_structures"
+            Directory for saving the parmed structures.
         kwargs : dict, optional
             The kwargs for each of the system initialization functions.
             See the doc strings for each function for allowable args.
@@ -259,6 +265,13 @@ class Initializer:
         self.system_mass = 0
         self.target_box = None
         self.charges = charges
+        self.save_parmed = save_parmed
+        if self.save_parmed:
+            os.makedirs(parmed_dir, exist_ok=True)
+            self.pmd_pickle_path = os.path.join(parmed_dir,
+                                                'pmd_{}_n{}_l{}'.format(self.system_parms.molecule,
+                                                                        self.system_parms.n_compounds,
+                                                                        self.system_parms.polymer_lengths))
 
         self.mb_compounds = self._generate_compounds()
         if self.system_type == "pack":
@@ -276,6 +289,13 @@ class Initializer:
                     f"You passed in {system_type}"
             )
 
+        if self.forcefield:
+            self._load_parmed_structure(untyped_system=system_init)
+            if self.remove_hydrogens:
+                self._remove_hydrogens()
+        else:
+            self.system = system_init
+
         if self.target_box is None:
             warn("A target box has not been set for this system. "
                  "The default cubic volume (Lx=Ly=Lz) will be used. "
@@ -283,13 +303,6 @@ class Initializer:
                  "target box."
             )
             self.set_target_box()
-
-        if self.forcefield:
-            self.system = self._apply_ff(untyped_system=system_init)
-            if self.remove_hydrogens:
-                self._remove_hydrogens()
-        else:
-            self.system = system_init
 
     def pack(self, expand_factor=7):
         """Uses PACKMOL via mBuild to randomlly fill a box
@@ -657,6 +670,22 @@ class Initializer:
             for a in typed_system.atoms:
                 a.charge = 0
         return typed_system
+
+    def _load_parmed_structure(self, untyped_system):
+        """Loads the parmed structure from file, if exists.
+        Otherwise, creates the parmed structure and saves it to file using pickle.
+        """
+        if self.pmd_pickle_path and os.path.exists(self.pmd_pickle_path):
+                # load parmed from file
+                f = open(self.pmd_pickle_path, "rb")
+                self.system = pickle.load(f)
+                f.close()
+        else:
+            self.system = self._apply_ff(untyped_system)
+            if self.pmd_pickle_path:
+                f = open(self.pmd_pickle_path, "wb")
+                pickle.dump(self.system, f)
+                f.close()
 
     def _remove_hydrogens(self):
         # Adjust mass and charge of heavy atoms:

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -268,10 +268,14 @@ class Initializer:
         self.save_parmed = save_parmed
         if self.save_parmed:
             os.makedirs(parmed_dir, exist_ok=True)
-            self.pmd_pickle_path = os.path.join(parmed_dir,
-                                                'pmd_{}_n{}_l{}'.format(self.system_parms.molecule,
-                                                                        self.system_parms.n_compounds,
-                                                                        self.system_parms.polymer_lengths))
+            self.pmd_pickle_path = os.path.join(
+                    parmed_dir,
+                    'pmd_{}_n{}_l{}'.format(
+                        self.system_parms.molecule,
+                        self.system_parms.n_compounds,
+                        self.system_parms.polymer_lengths
+                    )
+            )
 
         self.mb_compounds = self._generate_compounds()
         if self.system_type == "pack":


### PR DESCRIPTION
This PR saves the ParmEd structure built during system initialization to a file. After saving the ParmEd to the file, for any future initialization of the same system, ParmEd object is loaded from file instead of building it from scratch. This will save a significant amount of time, which makes running simulations with different parameters (density, temperature, ...) much faster. 

Details:
- This is an optional feature and it can be disabled by setting `save_parmed=False` in `Initializer` class.
- Default directory for saving the files is `pmd_structures`, which can be changed by setting `parmed_dir` argument in `Initializer` class.
- ParmEd object is stored using `pickle`. The reason I did not use[ ParmEd save function](https://parmed.github.io/ParmEd/html/api/parmed/parmed.structure.html#parmed.structure.Structure.save) is because it loses all the connections (bonds, angles and dihedrals)
