### PR TITLE
replace 0 with 1 when sampling from weibull distribution

### DIFF
--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -175,6 +175,11 @@ class System:
         mass_sampler = mass_distribution_dict["sampler"]
         mass_distribution = mass_distribution_dict["functional_form"]
         samples = np.round(mass_sampler(n_compounds)).astype(int)
+        if len(samples[samples == 0]) > 0:
+            samples[samples == 0] = 1
+            warn("Polymer lengths of 0 were returned from sampling. "
+                "They were replaced a length of 1"
+            )
         self.polymer_lengths = sorted(list(set(samples)))
         self.n_compounds = [
                 list(samples).count(x) for x in self.polymer_lengths


### PR DESCRIPTION
Fixes a long standing issue of zeros being returned when sampling the weibull distribution to obtain polymer lengths