### PR TITLE
Update environment files and fix charge behavior

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -1,19 +1,17 @@
 name: polybinder 
 channels:
-  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
-  - foyer=0.11.0
-  - freud=2.8.0
-  - gsd=2.5.1
-  - hoomd=3.2.0=*cpu*
-  - mbuild=0.14.2
-  - numpy=1.22
+  - foyer=0.11.3
+  - freud=2.12.1
+  - gsd=2.7.0
+  - hoomd=3.7.0=*cpu*
+  - mbuild=0.15.1
   - pip=22.0.4
   - pytest
   - pytest-cov
   - python=3.9
-  - scipy=1.8.0
+  - scipy=1.9.3
   - signac=1.7.0
   - signac-flow=0.18.1
   - pip:

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -1,19 +1,17 @@
-name: polybinder
+name: polybinder 
 channels:
-  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
-  - foyer=0.11.0
-  - freud=2.8.0
-  - gsd=2.5.1
-  - hoomd=3.2.0=*gpu*
-  - mbuild=0.14.2
-  - numpy=1.22
+  - foyer=0.11.3
+  - freud=2.12.1
+  - gsd=2.7.0
+  - hoomd=3.7.0=*gpu*
+  - mbuild=0.15.1
   - pip=22.0.4
   - pytest
   - pytest-cov
   - python=3.9
-  - scipy=1.8.0
+  - scipy=1.9.3
   - signac=1.7.0
   - signac-flow=0.18.1
   - pip:

--- a/environment-nohoomd.yml
+++ b/environment-nohoomd.yml
@@ -1,18 +1,16 @@
 name: polybinder 
 channels:
-  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
 dependencies:
-  - foyer=0.11.0
-  - freud=2.8.0
-  - gsd=2.5.1
-  - mbuild=0.14.2
-  - numpy=1.22
+  - foyer=0.11.3
+  - freud=2.12.1
+  - gsd=2.7.0
+  - mbuild=0.15.1
   - pip=22.0.4
   - pytest
   - pytest-cov
   - python=3.9
-  - scipy=1.8.0
+  - scipy=1.9.3
   - signac=1.7.0
   - signac-flow=0.18.1
   - pip:

--- a/polybinder/library/forcefields/pps_opls.xml
+++ b/polybinder/library/forcefields/pps_opls.xml
@@ -1,0 +1,48 @@
+<ForceField name="OPLS-AA" version="0.0.3" combining_rule="geometric">
+	<AtomTypes>
+		<Type name="opls_204" class="HS" element="H" mass="1.008" def="[H;X1]([S;%opls_200])" desc="H in any Thiol" overrides=""/>
+		<Type name="opls_145" class="CA" element="C" mass="12.011" def="[C;X3;r6]1[C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6]1" desc="" overrides=""/>
+		<Type name="opls_202" class="S" element="S" mass="32.06" def="[S;X2]" desc="S in any sulfide" overrides=""/>
+		<Type name="opls_146" class="HA" element="H" mass="1.008" def="[H][C;%opls_145]" desc="benzene H" overrides=""/>
+		<Type name="opls_200" class="SH" element="S" mass="32.06" def="[S;X2]H" desc="S in any Thiol" overrides="opls_202"/>
+	</AtomTypes>
+	<HarmonicBondForce>
+		<Bond class1="S" class2="CA" length="0.176" k="209200.0"/>
+		<Bond class1="HS" class2="SH" length="0.1336" k="229283.2"/>
+		<Bond class1="CA" class2="S" length="0.176" k="209200.0"/>
+		<Bond class1="CA" class2="CA" length="0.14" k="392459.2"/>
+		<Bond class1="HA" class2="CA" length="0.108" k="307105.6"/>
+		<Bond class1="SH" class2="CA" length="0.174" k="209200.0"/>
+	</HarmonicBondForce>
+	<HarmonicAngleForce>
+		<Angle class1="CA" class2="S" class3="CA" angle="1.72490889974599" k="627.6"/>
+		<Angle class1="CA" class2="SH" class3="HS" angle="1.67551608191" k="418.4"/>
+		<Angle class1="CA" class2="CA" class3="S" angle="2.08392312688" k="711.28"/>
+		<Angle class1="CA" class2="CA" class3="CA" angle="2.09439510239" k="527.184"/>
+		<Angle class1="CA" class2="CA" class3="SH" angle="2.09439510239" k="585.76"/>
+		<Angle class1="SH" class2="CA" class3="CA" angle="2.09439510239" k="585.76"/>
+		<Angle class1="CA" class2="CA" class3="HA" angle="2.09439510239" k="292.88"/>
+		<Angle class1="S" class2="CA" class3="CA" angle="2.08392312688" k="711.28"/>
+	</HarmonicAngleForce>
+	<RBTorsionForce>
+		<Proper class1="CA" class2="CA" class3="S" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="S" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="S" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="S" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="SH" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="HA" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="SH" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="SH" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="S" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
+	</RBTorsionForce>
+	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+		<Atom type="opls_204" charge="0.155" sigma="0.0" epsilon="0.0"/>
+		<Atom type="opls_145" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="opls_202" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="opls_146" charge="0.115" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="opls_200" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
+	</NonbondedForce>
+</ForceField>

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -929,12 +929,16 @@ def build_molecule(
             para = mb.load(os.path.join(COMPOUND_DIR, mol_dict["para_file"]))
             if charges:
                 charge_dict = mol_dict["para_charges"][charges]
+                para_head_charge = charge_dict[str(para.n_particles - 2)]
+                para_tail_charge = charge_dict[str(para.n_particles - 1)]
                 for idx, p in enumerate(para.particles()):
                     p.charge = charge_dict[str(idx)]
             if "M" in monomer_sequence:
                 meta = mb.load(os.path.join(COMPOUND_DIR, mol_dict["meta_file"]))
                 if charges:
                     charge_dict = mol_dict["meta_charges"][charges]
+                    meta_head_charge = charge_dict[str(para.n_particles - 2)]
+                    meta_tail_charge = charge_dict[str(para.n_particles - 1)]
                     for idx, p in enumerate(meta.particles()):
                         p.charge = charge_dict[str(idx)]
         except KeyError:
@@ -972,6 +976,15 @@ def build_molecule(
             )
 
     compound.build(n=1, sequence=monomer_sequence, add_hydrogens=True)
+    if charges:
+        if monomer_sequence[0] == "P":
+            compound[-2].charge = para_head_charge
+        elif monomer_sequence[0] == "M":
+            compound[-2].charge = meta_head_charge
+        if monomer_sequence[-1] == "P":
+            compound[-1].charge = para_tail_charge
+        elif monomer_sequence[-1] == "M":
+            compound[-1].charge = meta_tail_charge
     # Rotate to align with z-axis; important for initializing ordered systems
     # Rotations are hard-coded based on the mol2 files in the library
     if molecule == "PEKK":


### PR DESCRIPTION
This PR makes a small change to make sure charges are assigned to the head and tail hydrogen atoms added to each polymer chain, and works with the change of charge behavior in mBuild where charges default to `None` instead of 0.