### PR TITLE
Update Interface and Fused classes, renaname types in pps_opls FF

### DIFF
--- a/polybinder/library/forcefields/pps_opls-nosmarts.xml
+++ b/polybinder/library/forcefields/pps_opls-nosmarts.xml
@@ -39,10 +39,10 @@
 		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
 	</RBTorsionForce>
 	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-		<Atom type="hs" charge="" sigma="0.0" epsilon="0.0"/>
-		<Atom type="ca" charge="" sigma="0.355" epsilon="0.29288"/>
-		<Atom type="s" charge="" sigma="0.36" epsilon="1.48532"/>
-		<Atom type="ha" charge="" sigma="0.242" epsilon="0.12552"/>
-		<Atom type="sh" charge="" sigma="0.36" epsilon="1.7782"/>
+		<Atom type="hs" charge="0.0" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="0.0" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="s" charge="0.0" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="ha" charge="0.0" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="sh" charge="0.0" sigma="0.36" epsilon="1.7782"/>
 	</NonbondedForce>
 </ForceField>

--- a/polybinder/library/forcefields/pps_opls-nosmarts.xml
+++ b/polybinder/library/forcefields/pps_opls-nosmarts.xml
@@ -1,10 +1,10 @@
 <ForceField name="OPLS-AA" version="0.0.3" combining_rule="geometric">
 	<AtomTypes>
-		<Type name="opls_204" class="HS" element="H" mass="1.008" def="_opls_204" desc="H in any Thiol" overrides=""/>
-		<Type name="opls_145" class="CA" element="C" mass="12.011" def="_opls_145" desc="" overrides=""/>
-		<Type name="opls_202" class="S" element="S" mass="32.06" def="_opls_202" desc="S in any sulfide" overrides=""/>
-		<Type name="opls_146" class="HA" element="H" mass="1.008" def="_opls_146" desc="benzene H" overrides=""/>
-		<Type name="opls_200" class="SH" element="S" mass="32.06" def="_opls_200" desc="S in any Thiol" overrides="opls_202"/>
+		<Type name="hs" class="HS" element="_hs" mass="1.008" def="_hs" desc="H in any Thiol (opls_204)" overrides=""/>
+		<Type name="ca" class="CA" element="_ca" mass="12.011" def="_ca" desc="opls_145" overrides=""/>
+		<Type name="s" class="S" element="_s" mass="32.06" def="_s" desc="S in any sulfide (opls_202)" overrides=""/>
+		<Type name="ha" class="HA" element="_ha" mass="1.008" def="_ha" desc="benzene H (opls_146)" overrides=""/>
+		<Type name="sh" class="SH" element="_sh" mass="32.06" def="_sh" desc="S in any Thiol (opls_200)" overrides="s"/>
 	</AtomTypes>
 	<HarmonicBondForce>
 		<Bond class1="S" class2="CA" length="0.176" k="209200.0"/>
@@ -39,10 +39,10 @@
 		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
 	</RBTorsionForce>
 	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-		<Atom type="opls_204" charge="0.155" sigma="0.0" epsilon="0.0"/>
-		<Atom type="opls_145" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
-		<Atom type="opls_202" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
-		<Atom type="opls_146" charge="0.115" sigma="0.242" epsilon="0.12552"/>
-		<Atom type="opls_200" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
+		<Atom type="hs" charge="0.155" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="s" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="ha" charge="0.115" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="sh" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
 	</NonbondedForce>
 </ForceField>

--- a/polybinder/library/forcefields/pps_opls-nosmarts.xml
+++ b/polybinder/library/forcefields/pps_opls-nosmarts.xml
@@ -1,0 +1,48 @@
+<ForceField name="OPLS-AA" version="0.0.3" combining_rule="geometric">
+	<AtomTypes>
+		<Type name="opls_204" class="HS" element="H" mass="1.008" def="_opls_204" desc="H in any Thiol" overrides=""/>
+		<Type name="opls_145" class="CA" element="C" mass="12.011" def="_opls_145" desc="" overrides=""/>
+		<Type name="opls_202" class="S" element="S" mass="32.06" def="_opls_202" desc="S in any sulfide" overrides=""/>
+		<Type name="opls_146" class="HA" element="H" mass="1.008" def="_opls_146" desc="benzene H" overrides=""/>
+		<Type name="opls_200" class="SH" element="S" mass="32.06" def="_opls_200" desc="S in any Thiol" overrides="opls_202"/>
+	</AtomTypes>
+	<HarmonicBondForce>
+		<Bond class1="S" class2="CA" length="0.176" k="209200.0"/>
+		<Bond class1="HS" class2="SH" length="0.1336" k="229283.2"/>
+		<Bond class1="CA" class2="S" length="0.176" k="209200.0"/>
+		<Bond class1="CA" class2="CA" length="0.14" k="392459.2"/>
+		<Bond class1="HA" class2="CA" length="0.108" k="307105.6"/>
+		<Bond class1="SH" class2="CA" length="0.174" k="209200.0"/>
+	</HarmonicBondForce>
+	<HarmonicAngleForce>
+		<Angle class1="CA" class2="S" class3="CA" angle="1.805" k="627.6"/>
+		<Angle class1="CA" class2="SH" class3="HS" angle="1.67551608191" k="418.4"/>
+		<Angle class1="CA" class2="CA" class3="S" angle="2.08392312688" k="711.28"/>
+		<Angle class1="CA" class2="CA" class3="CA" angle="2.09439510239" k="527.184"/>
+		<Angle class1="CA" class2="CA" class3="SH" angle="2.09439510239" k="585.76"/>
+		<Angle class1="SH" class2="CA" class3="CA" angle="2.09439510239" k="585.76"/>
+		<Angle class1="CA" class2="CA" class3="HA" angle="2.09439510239" k="292.88"/>
+		<Angle class1="S" class2="CA" class3="CA" angle="2.08392312688" k="711.28"/>
+	</HarmonicAngleForce>
+	<RBTorsionForce>
+		<Proper class1="CA" class2="CA" class3="S" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="S" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="S" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="S" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="SH" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="HA" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="CA" class4="SH" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="SH" class2="CA" class3="CA" class4="HA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="S" class3="CA" class4="CA" c0="30.334" c1="0.0" c2="-30.334" c3="0.0" c4="0.0" c5="0.0"/>
+		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
+	</RBTorsionForce>
+	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+		<Atom type="opls_204" charge="0.155" sigma="0.0" epsilon="0.0"/>
+		<Atom type="opls_145" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="opls_202" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="opls_146" charge="0.115" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="opls_200" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
+	</NonbondedForce>
+</ForceField>

--- a/polybinder/library/forcefields/pps_opls-nosmarts.xml
+++ b/polybinder/library/forcefields/pps_opls-nosmarts.xml
@@ -39,10 +39,10 @@
 		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
 	</RBTorsionForce>
 	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-		<Atom type="hs" charge="0.155" sigma="0.0" epsilon="0.0"/>
-		<Atom type="ca" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
-		<Atom type="s" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
-		<Atom type="ha" charge="0.115" sigma="0.242" epsilon="0.12552"/>
-		<Atom type="sh" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
+		<Atom type="hs" charge="" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="s" charge="" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="ha" charge="" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="sh" charge="" sigma="0.36" epsilon="1.7782"/>
 	</NonbondedForce>
 </ForceField>

--- a/polybinder/library/forcefields/pps_opls.xml
+++ b/polybinder/library/forcefields/pps_opls.xml
@@ -39,10 +39,10 @@
 		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
 	</RBTorsionForce>
 	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-		<Atom type="hs" charge="" sigma="0.0" epsilon="0.0"/>
-		<Atom type="ca" charge="" sigma="0.355" epsilon="0.29288"/>
-		<Atom type="s" charge="" sigma="0.36" epsilon="1.48532"/>
-		<Atom type="ha" charge="" sigma="0.242" epsilon="0.12552"/>
-		<Atom type="sh" charge="" sigma="0.36" epsilon="1.7782"/>
+		<Atom type="hs" charge="0.0" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="0.0" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="s" charge="0.0" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="ha" charge="0.0" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="sh" charge="0.0" sigma="0.36" epsilon="1.7782"/>
 	</NonbondedForce>
 </ForceField>

--- a/polybinder/library/forcefields/pps_opls.xml
+++ b/polybinder/library/forcefields/pps_opls.xml
@@ -1,10 +1,10 @@
 <ForceField name="OPLS-AA" version="0.0.3" combining_rule="geometric">
 	<AtomTypes>
-		<Type name="opls_204" class="HS" element="H" mass="1.008" def="[H;X1]([S;%opls_200])" desc="H in any Thiol" overrides=""/>
-		<Type name="opls_145" class="CA" element="C" mass="12.011" def="[C;X3;r6]1[C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6]1" desc="" overrides=""/>
-		<Type name="opls_202" class="S" element="S" mass="32.06" def="[S;X2]" desc="S in any sulfide" overrides=""/>
-		<Type name="opls_146" class="HA" element="H" mass="1.008" def="[H][C;%opls_145]" desc="benzene H" overrides=""/>
-		<Type name="opls_200" class="SH" element="S" mass="32.06" def="[S;X2]H" desc="S in any Thiol" overrides="opls_202"/>
+		<Type name="hs" class="HS" element="H" mass="1.008" def="[H;X1]([S;%sh])" desc="H in any Thiol (opls_204)" overrides=""/>
+		<Type name="ca" class="CA" element="C" mass="12.011" def="[C;X3;r6]1[C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6][C;X3;r6]1" desc="Aromatic C (opls_145)" overrides=""/>
+		<Type name="s" class="S" element="S" mass="32.06" def="[S;X2]" desc="S in any sulfide (opls_202)" overrides=""/>
+		<Type name="ha" class="HA" element="H" mass="1.008" def="[H][C;%ca]" desc="benzene H (opls_146)" overrides=""/>
+		<Type name="sh" class="SH" element="S" mass="32.06" def="[S;X2]H" desc="S in any Thiol (opls_200)" overrides="s"/>
 	</AtomTypes>
 	<HarmonicBondForce>
 		<Bond class1="S" class2="CA" length="0.176" k="209200.0"/>
@@ -39,10 +39,10 @@
 		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
 	</RBTorsionForce>
 	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-		<Atom type="opls_204" charge="0.155" sigma="0.0" epsilon="0.0"/>
-		<Atom type="opls_145" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
-		<Atom type="opls_202" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
-		<Atom type="opls_146" charge="0.115" sigma="0.242" epsilon="0.12552"/>
-		<Atom type="opls_200" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
+		<Atom type="hs" charge="0.155" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="s" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="ha" charge="0.115" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="sh" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
 	</NonbondedForce>
 </ForceField>

--- a/polybinder/library/forcefields/pps_opls.xml
+++ b/polybinder/library/forcefields/pps_opls.xml
@@ -39,10 +39,10 @@
 		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
 	</RBTorsionForce>
 	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-		<Atom type="hs" charge="0.155" sigma="0.0" epsilon="0.0"/>
-		<Atom type="ca" charge="-0.115" sigma="0.355" epsilon="0.29288"/>
-		<Atom type="s" charge="-0.335" sigma="0.36" epsilon="1.48532"/>
-		<Atom type="ha" charge="0.115" sigma="0.242" epsilon="0.12552"/>
-		<Atom type="sh" charge="-0.335" sigma="0.36" epsilon="1.7782"/>
+		<Atom type="hs" charge="" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="s" charge="" sigma="0.36" epsilon="1.48532"/>
+		<Atom type="ha" charge="" sigma="0.242" epsilon="0.12552"/>
+		<Atom type="sh" charge="" sigma="0.36" epsilon="1.7782"/>
 	</NonbondedForce>
 </ForceField>

--- a/polybinder/library/forcefields/pps_opls.xml
+++ b/polybinder/library/forcefields/pps_opls.xml
@@ -39,8 +39,8 @@
 		<Proper class1="CA" class2="CA" class3="SH" class4="HS" c0="4.6024" c1="0.0" c2="-4.6024" c3="0.0" c4="0.0" c5="0.0"/>
 	</RBTorsionForce>
 	<NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-		<Atom type="hs" charge="0.0" sigma="0.0" epsilon="0.0"/>
-		<Atom type="ca" charge="0.0" sigma="0.355" epsilon="0.29288"/>
+		<Atom type="hs" charge="0.1" sigma="0.0" epsilon="0.0"/>
+		<Atom type="ca" charge="-0.1" sigma="0.355" epsilon="0.29288"/>
 		<Atom type="s" charge="0.0" sigma="0.36" epsilon="1.48532"/>
 		<Atom type="ha" charge="0.0" sigma="0.242" epsilon="0.12552"/>
 		<Atom type="sh" charge="0.0" sigma="0.36" epsilon="1.7782"/>

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -865,14 +865,16 @@ def _gsd_to_mbuild(
     atom_types = [snap.particles.types[i] for i in snap.particles.typeid]
     if not coarse_grain:
         elements = [element_mapping[i] for i in atom_types]
+        names = [f"_{type}" for type in atom_types]
     else:
         elements = [None for i in atom_types]
+        names = atom_types
 
     comp = mb.Compound()
-    for pos, charge, mass, element, atom_type in zip(
-            pos_wrap, charges, masses, elements, atom_types):
+    for pos, charge, mass, element, name in zip(
+            pos_wrap, charges, masses, elements, names):
         child = mb.Compound(
-                name=f"_{atom_type}", pos=pos, charge=charge, mass=mass, element=element
+                name=name, pos=pos, charge=charge, mass=mass, element=element
         )
         comp.add(child)
 

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -430,7 +430,13 @@ class Initializer:
         self.system_type = "crystal"
     
     def coarse_grain_system(
-            self, use_monomers=False, use_components=False, bead_mapping=None
+            self,
+            ref_distance,
+            ref_mass,
+            use_monomers=False,
+            use_components=False,
+            bead_mapping=None,
+
     ):
         import polybinderCG.mbuild_cg as mbcg
 
@@ -444,7 +450,10 @@ class Initializer:
 
         for idx, comp in enumerate(self.mb_compounds):
             cg_comp = mbcg.System(
-                    mb_compound=comp, molecule=self.system_parms.molecule
+                    mb_compound=comp,
+                    molecule=self.system_parms.molecule,
+                    ref_distanc=ref_distance,
+                    ref_mass=ref_mass
             )
             if use_monomers:
                 for mol in cg_comp.molecules:

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -657,10 +657,12 @@ class Initializer:
 
 
 class Fused:
-    def __init__(self, gsd_file, ref_distance):
+    def __init__(self, gsd_file, ref_distance, forcefield):
         self.gsd_file = gsd_file
         self.ref_distance = ref_distance
+        self.forcefield = forcefield
         self.system_type = "interface"
+
         system = _gsd_to_mbuild(self.gsd_file, self.ref_distance)
         system.box = mb.box.Box.from_mins_maxs_angles(
                 mins=(0,0,0),
@@ -673,7 +675,7 @@ class Fused:
                 system.box.Lz / 2,]
         )
 
-        ff_path = f"{FF_DIR}/gaff-nosmarts.xml"
+        ff_path = f"{FF_DIR}/{self.forcefield}-nosmarts.xml"
         forcefield = foyer.Forcefield(forcefield_files=ff_path)
         self.system = forcefield.apply(system)
 
@@ -744,7 +746,6 @@ class Interface:
         )
 
         ff_path = f"{FF_DIR}/{self.forcefield}-nosmarts.xml"
-        ff_path = f"{FF_DIR}/gaff-nosmarts.xml"
         forcefield = foyer.Forcefield(forcefield_files=ff_path)
         self.system = forcefield.apply(interface)
 

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -430,12 +430,7 @@ class Initializer:
         self.system_type = "crystal"
     
     def coarse_grain_system(
-            self,
-            ref_distance,
-            ref_mass,
-            use_monomers=False,
-            use_components=False,
-            bead_mapping=None,
+            self, use_monomers=False, use_components=False, bead_mapping=None,
 
     ):
         import polybinderCG.mbuild_cg as mbcg
@@ -450,10 +445,7 @@ class Initializer:
 
         for idx, comp in enumerate(self.mb_compounds):
             cg_comp = mbcg.System(
-                    mb_compound=comp,
-                    molecule=self.system_parms.molecule,
-                    ref_distance=ref_distance,
-                    ref_mass=ref_mass
+                    mb_compound=comp, molecule=self.system_parms.molecule,
             )
             if use_monomers:
                 for mol in cg_comp.molecules:

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -679,7 +679,8 @@ class Fused:
                 gsd_file=self.gsd_file,
                 ref_distance=self.ref_distance,
                 ref_energy=self.ref_energy,
-                ref_mass=self.ref_mass
+                ref_mass=self.ref_mass,
+                coarse_grain=coarse_grain
         )
         system_mb.box = mb.box.Box.from_mins_maxs_angles(
                 mins=(0,0,0),
@@ -777,13 +778,15 @@ class Interface:
                 gsd_file=slab_files[0],
                 ref_distance=self.ref_distance,
                 ref_energy=self.ref_energy,
-                ref_mass=self.ref_mass
+                ref_mass=self.ref_mass,
+                coarse_grain=coarse_grain
         )
         slab_2 = _gsd_to_mbuild(
                 gsd_file=slab_files[1],
                 ref_distance=self.ref_distance,
                 ref_energy=self.ref_energy,
-                ref_mass=self.ref_mass
+                ref_mass=self.ref_mass,
+                coarse_grain=coarse_grain
         )
         interface.add(new_child=slab_1, label="left")
         interface.add(new_child=slab_2, label="right")
@@ -828,7 +831,13 @@ class Interface:
             self.system = parmed_system
 
 
-def _gsd_to_mbuild(gsd_file, ref_distance, ref_energy, ref_mass):
+def _gsd_to_mbuild(
+        gsd_file,
+        ref_distance,
+        ref_energy,
+        ref_mass,
+        coarse_grain=False
+):
     """Creates an mbuild.Compound system from a hoomd GSD file.
     Assumes that the positions and charges stored in the gsd file
     are the reduced values used during the simulation.
@@ -854,7 +863,10 @@ def _gsd_to_mbuild(gsd_file, ref_distance, ref_energy, ref_mass):
     charges = snap.particles.charge * charge_factor
     masses = snap.particles.mass * ref_mass
     atom_types = [snap.particles.types[i] for i in snap.particles.typeid]
-    elements = [element_mapping[i] for i in atom_types]
+    if not coarse_grain:
+        elements = [element_mapping[i] for i in atom_types]
+    else:
+        elements = [None for i in atom_types]
 
     comp = mb.Compound()
     for pos, charge, mass, element, atom_type in zip(

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -763,6 +763,9 @@ def _gsd_to_mbuild(gsd_file, ref_distance):
         "opls_202": "S",
         "opls_146": "H",
         "opls_200": "S",
+        "hs": "H",
+        "s": "S",
+        "sh": "S",
 
     }
     snap = trajectory = gsd.hoomd.open(gsd_file)[-1]

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -452,7 +452,7 @@ class Initializer:
             cg_comp = mbcg.System(
                     mb_compound=comp,
                     molecule=self.system_parms.molecule,
-                    ref_distanc=ref_distance,
+                    ref_distance=ref_distance,
                     ref_mass=ref_mass
             )
             if use_monomers:

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -699,9 +699,10 @@ class Interface:
         "x", "y" or "z"
 
     """
-    def __init__(self, slabs, ref_distance, gap=0.1, weld_axis="x"):
+    def __init__(self, slabs, ref_distance, forcefield, gap=0.1, weld_axis="x"):
         self.system_type = "interface"
         self.ref_distance = ref_distance
+        self.forcefield = forcefield
         if not isinstance(slabs, list):
             slabs = [slabs]
         if len(slabs) == 2:
@@ -742,6 +743,7 @@ class Interface:
                 interface.box.Lz / 2,]
         )
 
+        ff_path = f"{FF_DIR}/{self.forcefield}-nosmarts.xml"
         ff_path = f"{FF_DIR}/gaff-nosmarts.xml"
         forcefield = foyer.Forcefield(forcefield_files=ff_path)
         self.system = forcefield.apply(interface)

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -755,6 +755,12 @@ def _gsd_to_mbuild(gsd_file, ref_distance):
         "c": "C",
         "ho": "H",
         "ha": "H",
+        "opls_204": "H",
+        "opls_145": "C",
+        "opls_202": "S",
+        "opls_146": "H",
+        "opls_200": "S",
+
     }
     snap = trajectory = gsd.hoomd.open(gsd_file)[-1]
     pos_wrap = snap.particles.position * ref_distance

--- a/polybinder/system.py
+++ b/polybinder/system.py
@@ -605,6 +605,11 @@ class Initializer:
             print(f"Resulting net charge of {net_charge}")
             print("-----------------------------------------------------------")
             print()
+        # Can't have zero charges in opls-type FFs (Parmed issue)
+        # Iterate and zero the charges here.
+        else:
+            for a in typed_system.atoms:
+                a.charge = 0
         return typed_system
 
     def _load_parmed_structure(self, untyped_system):

--- a/polybinder/tests/base_test.py
+++ b/polybinder/tests/base_test.py
@@ -16,6 +16,7 @@ class BaseTest:
             slabs=os.path.join(ASSETS_DIR, "test_slab_xwall.gsd"),
             ref_distance=0.33997,
             gap=0.1,
+            forcefield="gaff",
             weld_axis="x"
         )
         return slab
@@ -26,6 +27,7 @@ class BaseTest:
             slabs=os.path.join(ASSETS_DIR, "test_slab_ywall.gsd"),
             ref_distance=0.33997,
             gap=0.1,
+            forcefield="gaff",
             weld_axis="y"
         )
         return slab
@@ -36,7 +38,8 @@ class BaseTest:
             slabs=os.path.join(ASSETS_DIR, "test_slab_zwall.gsd"),
             ref_distance=0.33997,
             gap=0.1,
-            weld_axis="z"
+            weld_axis="z",
+            forcefield="gaff",
         )
         return slab
 

--- a/polybinder/tests/base_test.py
+++ b/polybinder/tests/base_test.py
@@ -15,6 +15,8 @@ class BaseTest:
         slab = Interface(
             slabs=os.path.join(ASSETS_DIR, "test_slab_xwall.gsd"),
             ref_distance=0.33997,
+            ref_energy=0.21,
+            ref_mass=15.98,
             gap=0.1,
             forcefield="gaff",
             weld_axis="x"
@@ -26,6 +28,8 @@ class BaseTest:
         slab = Interface(
             slabs=os.path.join(ASSETS_DIR, "test_slab_ywall.gsd"),
             ref_distance=0.33997,
+            ref_energy=0.21,
+            ref_mass=15.98,
             gap=0.1,
             forcefield="gaff",
             weld_axis="y"
@@ -37,6 +41,8 @@ class BaseTest:
         slab = Interface(
             slabs=os.path.join(ASSETS_DIR, "test_slab_zwall.gsd"),
             ref_distance=0.33997,
+            ref_energy=0.21,
+            ref_mass=15.98,
             gap=0.1,
             weld_axis="z",
             forcefield="gaff",

--- a/polybinder/tests/test_systems.py
+++ b/polybinder/tests/test_systems.py
@@ -102,7 +102,10 @@ class TestSystems(BaseTest):
     def test_fused(self):
         fused = Fused(
                 gsd_file=os.path.join(ASSETS_DIR, "test_slab_xwall.gsd"),
-                ref_distance=0.33997
+                ref_distance=0.33997,
+                ref_energy=0.21,
+                ref_mass=15.98,
+                forcefield="gaff",
             )
 
     def test_interface_2_files(self):
@@ -110,7 +113,10 @@ class TestSystems(BaseTest):
                 slabs=[os.path.join(ASSETS_DIR, "test_slab_xwall.gsd"), 
                     os.path.join(ASSETS_DIR, "test_slab_xwall.gsd")
                 ],
-                ref_distance=0.33997
+                ref_distance=0.33997,
+                ref_energy=0.21,
+                ref_mass=15.98,
+                forcefield="gaff",
             )
 
     def test_interface_y(self):
@@ -119,6 +125,9 @@ class TestSystems(BaseTest):
                     os.path.join(ASSETS_DIR, "test_slab_ywall.gsd")
                 ],
                 ref_distance=0.33997,
+                ref_energy=0.21,
+                ref_mass=15.98,
+                forcefield="gaff",
                 weld_axis="y"
             )
 
@@ -129,6 +138,9 @@ class TestSystems(BaseTest):
                     os.path.join(ASSETS_DIR, "test_slab_zwall.gsd")
                 ],
                 ref_distance=0.33997,
+                ref_energy=0.21,
+                ref_mass=15.98,
+                forcefield="gaff",
                 weld_axis="z"
             )
 
@@ -501,7 +513,10 @@ class TestSystems(BaseTest):
     def test_gsd_to_mbuild(self):
         gsd_file = os.path.join(ASSETS_DIR, "test_slab_xwall.gsd")
         mb_comp = polybinder.system._gsd_to_mbuild(
-                gsd_file=gsd_file, ref_distance=3.39
+                gsd_file=gsd_file,
+                ref_distance=3.39,
+                ref_energy=0.21,
+                ref_mass=15.98
             )
         mb_pos = [i.xyz for i in mb_comp.particles()]
         with gsd.hoomd.open(gsd_file) as traj:


### PR DESCRIPTION
This PR makes some needed changes for the Interface and Fused system classes that are required to work with other changes made recently (e.g. populating charges when creating an Interface system).

This also renames the atom types in the `pps_opls.xml` file.  This change is required to use the no-SMARTS method of applying a foyer Forcefield, where the name and element must be the same as the particle name in the mBuild compound, but with a leading underscore.  There were parsing issues with the opls style names that already have an underscore in the name.