### PR TITLE
Add an efactor parameter to adjust epsilon values

### DIFF
--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -94,7 +94,7 @@ class Simulation:
         auto_scale=True,
         ref_values=None,
         mode="auto",
-        e_factor=None,
+        e_factor=1.0,
         gsd_write=1e4,
         log_write=1e3,
         seed=42,
@@ -187,7 +187,7 @@ class Simulation:
                     auto_scale=self.auto_scale,
                     pppm_kwargs = {"Nx": 16, "Ny": 16, "Nz": 16, }
             )
-            if self.e_factor and self.e_factor != 1.0:
+            if self.e_factor != 1.0:
                 print("Epsilon values scaled by an e_factor of {self.e_factor}")
                 for param in self.forcefield[0].params:
                     init_epsilon = self.forcefield[0].params[param]['epsilon']

--- a/polybinder/simulate.py
+++ b/polybinder/simulate.py
@@ -94,6 +94,7 @@ class Simulation:
         auto_scale=True,
         ref_values=None,
         mode="auto",
+        e_factor=None,
         gsd_write=1e4,
         log_write=1e3,
         seed=42,
@@ -111,6 +112,7 @@ class Simulation:
         self.auto_scale = auto_scale
         self.ref_values = ref_values
         self.mode = mode.lower()
+        self.e_factor = e_factor
         self.gsd_write = gsd_write
         self.log_write = log_write
         self.seed = seed
@@ -185,6 +187,15 @@ class Simulation:
                     auto_scale=self.auto_scale,
                     pppm_kwargs = {"Nx": 16, "Ny": 16, "Nz": 16, }
             )
+            if self.e_factor and self.e_factor != 1.0:
+                print("Epsilon values scaled by an e_factor of {self.e_factor}")
+                for param in self.forcefield[0].params:
+                    init_epsilon = self.forcefield[0].params[param]['epsilon']
+                    new_epsilon = init_epsilon * self.e_factor 
+                    self.forcefield[0].params[param]['epsilon'] = new_epsilon
+                    print(param)
+                    print(f"{init_epsilon} changed to {new_epsilon}")
+                    print()
             if self.restart:
                 self.sim.create_state_from_gsd(self.restart)
             else:

--- a/polybinder/tests/test_simulations.py
+++ b/polybinder/tests/test_simulations.py
@@ -6,6 +6,18 @@ from polybinder import simulate
 
 
 class TestSimulate(BaseTest):
+    def test_efactor(self, pps_system_charges):
+        simulation = simulate.Simulation(
+                pps_system_charges,
+                tau_p=0.1,
+                e_factor=0.5,
+                dt=0.0001,
+                mode="cpu"
+        )
+        for param in simulation.forcefield[0].params:
+            assert simulation.forcefield[0].params[param]['epsilon'] < 1.0
+        simulation.quench(kT=1.0, n_steps=500)
+
     def test_charges_sim(self, pps_system_charges):
         simulation = simulate.Simulation(
                 pps_system_charges,


### PR DESCRIPTION
This PR lets us adjust the epsilon values from the forcefield on the fly using an `e_factor` parameter in the `Simulation` class.  The epsilon values are adjusted directly in the `hoomd.md.pair.LJ` parameter dictionary.

